### PR TITLE
- Fix HitboxEntity falses caused by wrong hitbox modeling for Falling…

### DIFF
--- a/src/main/java/ac/grim/grimac/manager/init/load/PacketEventsInit.java
+++ b/src/main/java/ac/grim/grimac/manager/init/load/PacketEventsInit.java
@@ -30,7 +30,7 @@ public class PacketEventsInit implements Initable {
             GrimAPI.INSTANCE.signalCriticalFailure();
             throw new RuntimeException("\n" +
                     "******************************************************\n" +
-                    "GrimAC requires PacketEvents > 2.7.0\n" +
+                    "GrimAC requires PacketEvents > " + NEWEST_UNSUPPORTED_PE_VERSION + "\n" +
                     "Please update PacketEvents to a compatible version.\n" +
                     "This is a critical error. GrimAC will be disabled.\n" +
                     "*****************************************************");

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityPainting.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityPainting.java
@@ -1,8 +1,13 @@
 package ac.grim.grimac.utils.data.packetentity;
 
 import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
+import ac.grim.grimac.utils.math.GrimMath;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.world.Direction;
+import com.github.retrooper.packetevents.protocol.world.states.enums.Axis;
+import com.github.retrooper.packetevents.util.Vector3d;
+import com.github.retrooper.packetevents.util.Vector3i;
 import lombok.Getter;
 
 import java.util.UUID;
@@ -10,10 +15,124 @@ import java.util.UUID;
 @Getter
 public class PacketEntityPainting extends PacketEntity {
 
-    private final Direction direction;
+    private final Direction side;
+    public SimpleCollisionBox paintingHitBox = new SimpleCollisionBox(trackedServerPosition.getPos().x, trackedServerPosition.getPos().y, trackedServerPosition.getPos().z,
+            trackedServerPosition.getPos().x, trackedServerPosition.getPos().y, trackedServerPosition.getPos().z);
+
+    private int width, height;
 
     public PacketEntityPainting(GrimPlayer player, UUID uuid, double x, double y, double z, Direction direction) {
         super(player, uuid, EntityTypes.PAINTING, x, y, z);
-        this.direction = direction;
+        this.side = direction;
+    }
+
+    public SimpleCollisionBox calculateBoundingBoxDimensions(int width, int height) {
+        if (this.width == width && this.height == height) return paintingHitBox;
+
+        this.width = width;
+        this.height = height;
+
+        float f = 0.46875F;
+        System.out.println("f: " + f);
+
+        Vector3d trackedServerPositionVector = this.trackedServerPosition.getPos();
+        Vector3i attachedBlockPos = new Vector3i(GrimMath.floor(trackedServerPositionVector.getX()),
+                GrimMath.floor(trackedServerPositionVector.getY()),
+                GrimMath.floor(trackedServerPositionVector.getZ()));
+        Vector3d vec3d = attachedBlockPos.toVector3d().add(0.5, 0.5, 0.5);
+
+        System.out.println("Initial vec3d (center of block): " + vec3d);
+        System.out.println("Side: " + side);
+
+        vec3d = offset(vec3d, side, -f);
+        System.out.println("vec3d after offset to back: " + vec3d);
+
+        double d = this.getOffset(width);
+        double e = this.getOffset(height);
+        System.out.println("d (horizontal offset): " + d + ", e (vertical offset): " + e);
+
+        Direction direction = rotateYCounterclockwise(side);
+        System.out.println("Perpendicular direction: " + direction);
+
+        Vector3d vec3d2 = offset(vec3d, direction, d);
+        System.out.println("vec3d2 after horizontal offset: " + vec3d2);
+        vec3d2 = offset(vec3d2, Direction.UP, e);
+        System.out.println("vec3d2 after vertical offset: " + vec3d2);
+
+        Axis axis = this.getAxis(side);
+        System.out.println("Axis: " + axis);
+
+        double g = axis == Axis.X ? 0.0625 : (double) width;
+        double h = (double) height;
+        double i = axis == Axis.Z ? 0.0625 : (double) width;
+        System.out.println("g: " + g + ", h: " + h + ", i: " + i);
+
+        SimpleCollisionBox box = new SimpleCollisionBox(
+                vec3d2.getX() - g/2, vec3d2.getY() - h/2, vec3d2.getZ() - i/2,
+                vec3d2.getX() + g/2, vec3d2.getY() + h/2, vec3d2.getZ() + i/2
+        );
+        System.out.println("Final box: " + box);
+        System.out.println("--- End calculation ---");
+        return box;
+    }
+
+    private double getOffset(int length) {
+        return length % 2 == 0 ? 0.5 : 0.0;
+    }
+
+    private Direction rotateYCounterclockwise(Direction side) {
+        switch (side) {
+            case NORTH:
+                return Direction.WEST;
+            case SOUTH:
+                return Direction.EAST;
+            case WEST:
+                return Direction.SOUTH;
+            case EAST:
+                return Direction.NORTH;
+            default:
+                throw new IllegalStateException("Unable to get CCW facing of " + this);
+        }
+    }
+
+    private Vector3d offset(Vector3d vector3d, Direction side, double value) {
+        Vector3i vec3i = getDirectionVector(side);
+        //return vector3d.add(value * vec3i.getX(), value * vec3i.getY(), value * vec3i.getZ()); //Incorrect
+        return new Vector3d(vector3d.getX() + value * vec3i.getX(), vector3d.getY() + value * vec3i.getY(), vector3d.getZ() + value * vec3i.getZ()); //Correct
+    }
+
+    private Vector3i getDirectionVector(Direction side) {
+        switch (side) {
+            case DOWN:
+                return new Vector3i(0, -1, 0);
+            case UP:
+                return new Vector3i(0, 1, 0);
+            case NORTH:
+                return new Vector3i(0, 0, -1);
+            case SOUTH:
+                return new Vector3i(0, 0, 1);
+            case WEST:
+                return new Vector3i(-1, 0, 0);
+            case EAST:
+                return new Vector3i(1, 0, 0);
+            default:
+                throw new IllegalStateException("Impossible direction: " + side);
+        }
+    }
+
+    private Axis getAxis(Direction direction) {
+        switch (side) {
+            case DOWN:
+            case UP:
+                return Axis.Y;
+            case NORTH:
+            case SOUTH:
+                return Axis.Z;
+            case WEST:
+            case EAST:
+                return Axis.X;
+            default:
+                throw new IllegalStateException("Impossible direction: " + side);
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -22,6 +22,8 @@ import com.github.retrooper.packetevents.protocol.potion.PotionType;
 import com.github.retrooper.packetevents.protocol.potion.PotionTypes;
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
 import com.github.retrooper.packetevents.protocol.world.Direction;
+import com.github.retrooper.packetevents.protocol.world.painting.PaintingVariant;
+import com.github.retrooper.packetevents.protocol.world.painting.PaintingVariants;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUpdateAttributes;
@@ -189,7 +191,7 @@ public class CompensatedEntities {
         } else if (EntityTypes.ARMOR_STAND.equals(entityType)) {
             packetEntity = new PacketEntityArmorStand(player, uuid, entityType, position.getX(), position.getY(), position.getZ(), data);
         } else if (EntityTypes.PAINTING.equals(entityType)) {
-            packetEntity = new PacketEntityPainting(player, uuid, position.x, position.y, position.z, Direction.getByHorizontalIndex(data));
+            packetEntity = new PacketEntityPainting(player, uuid, position.x, position.y, position.z, Direction.values()[data]);
         } else if (EntityTypes.GUARDIAN.equals(entityType)) {
             packetEntity = new PacketEntityGuardian(player, uuid, entityType, position.x, position.y, position.z, false); // can still be an Elder Guardian in 1.8-1.10.2 from entity metadata updates
         } else if (EntityTypes.ELDER_GUARDIAN.equals(entityType)) {
@@ -483,6 +485,21 @@ public class CompensatedEntities {
                 int info = (Integer) guardianByte.getValue(); // wiki says this is a byte but testing on 1.8 shows its an integer
                 ((PacketEntityGuardian) entity).isElder = (info & isElderlyBitMask) != 0;
             }
+        } else if (entity instanceof PacketEntityPainting) {
+            int index;
+
+            // per usual the MC wiki is wrong on the index of the passed data
+            index = 8;
+            EntityData paintingRegistryData = WatchableIndexUtil.getIndex(watchableObjects, index);
+            if (paintingRegistryData != null) {
+                Integer paintingRegistryID = (Integer) paintingRegistryData.getValue();
+                // if this is null that means there is a mapping error, just let it error out so we can fix it
+                PaintingVariant paintingVariant = PaintingVariants.getById(player.getClientVersion(), paintingRegistryID - 1);
+
+                PacketEntityPainting packetEntityPainting = ((PacketEntityPainting) entity);
+                packetEntityPainting.paintingHitBox = packetEntityPainting.calculateBoundingBoxDimensions(paintingVariant.getWidth(), paintingVariant.getHeight());
+            }
+
         }
 
         if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_9_4)) {

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
@@ -120,6 +120,8 @@ public final class BoundingBoxSize {
             return 0.3125f;
         } else if (EntityTypes.ARMOR_STAND.equals(type)) {
             return 0.5F;
+        } else if (EntityTypes.FALLING_BLOCK.equals(type)) {
+            return 0.98F;
         }
         return 0.6f;
     }
@@ -393,6 +395,8 @@ public final class BoundingBoxSize {
             return 0.3125f;
         } else if (EntityTypes.ARMOR_STAND.equals(type)) {
             return 1.975F;
+        } else if (EntityTypes.FALLING_BLOCK.equals(type)) {
+            return 0.98F;
         }
         return 1.95f;
     }

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BukkitNMS.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BukkitNMS.java
@@ -1,6 +1,8 @@
 package ac.grim.grimac.utils.nmsutil;
 
+import ac.grim.grimac.GrimAPI;
 import com.github.retrooper.packetevents.PacketEvents;
+import io.github.retrooper.packetevents.util.folia.FoliaScheduler;
 import lombok.experimental.UtilityClass;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -18,10 +20,14 @@ public class BukkitNMS {
     private final @NotNull Predicate<@NotNull Player> resetActiveBukkitItem;
 
     public void resetBukkitItemUsage(@Nullable Player player) {
-        if (player != null && resetActiveBukkitItem.test(player)) {
-            // only update if they were using an item to prevent certain issues
-            player.updateInventory();
-        }
+        if (player == null) return;
+
+        FoliaScheduler.getEntityScheduler().run(player, GrimAPI.INSTANCE.getPlugin(), (unused) -> {
+            if (resetActiveBukkitItem.test(player)) {
+                // only update if they were using an item to prevent certain issues
+                player.updateInventory();
+            }
+        }, null);
     }
 
     static {

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.utils.nmsutil;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
+import ac.grim.grimac.utils.data.packetentity.PacketEntityPainting;
 import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 
 public class GetBoundingBox {
@@ -57,6 +58,18 @@ public class GetBoundingBox {
     }
 
     public static void expandBoundingBoxByEntityDimensions(SimpleCollisionBox box, GrimPlayer player, PacketEntity entity) {
+        if (entity instanceof PacketEntityPainting) {
+            SimpleCollisionBox paintingBox = ((PacketEntityPainting) entity).paintingHitBox;
+            // Copy the painting's hitbox dimensions
+            box.minX = paintingBox.minX;
+            box.minY = paintingBox.minY;
+            box.minZ = paintingBox.minZ;
+            box.maxX = paintingBox.maxX;
+            box.maxY = paintingBox.maxY;
+            box.maxZ = paintingBox.maxZ;
+            return;
+        }
+
         double[] dimensions = getEntityDimensions(player, entity);
         double halfWidth = dimensions[0] / 2.0;
         double height = dimensions[1];


### PR DESCRIPTION
… Blocks and Paintings

  - Painting hitboxes only tested on 1.21. Any issues with other versions should be reported and fixed in a subsequent release.
- Fix upstream thread exception when accessing bukkit methods from netty threads
- Fix PacketEvents version check error message

Note: **If you are using the lite version**, fully fixing the falses with paintings requires merging in PRs from PacketEvents that are not in upstream yet. You can use use PE built from this PR: https://github.com/retrooper/packetevents/pull/1134 in the meantime.