### PR TITLE
Implement VL scaling with punishment reset support

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/prediction/OffsetHandler.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/prediction/OffsetHandler.java
@@ -20,6 +20,8 @@ public class OffsetHandler extends Check implements PostPredictionCheck {
     double immediateSetbackThreshold;
     double maxAdvantage;
     double maxCeiling;
+    double vlScale;
+    double maxVlsPerFlag;
     double setbackViolationThreshold;
     // Current advantage gained
     double advantageGained = 0;
@@ -64,6 +66,12 @@ public class OffsetHandler extends Check implements PostPredictionCheck {
                         predictionComplete.setIdentifier(flagId);
                     }
 
+                    int extra = (int) Math.min(maxVlsPerFlag, Math.ceil(offset * vlScale) - 1.0);
+                    if (extra > 0) {
+                        violations += extra;
+                        player.punishmentManager.recordExtraViolations(this, extra);
+                    }
+
                     if ((advantageGained >= maxAdvantage || offset >= immediateSetbackThreshold)
                             && !isNoSetbackPermission()
                             && violations >= setbackViolationThreshold) {
@@ -104,9 +112,12 @@ public class OffsetHandler extends Check implements PostPredictionCheck {
         immediateSetbackThreshold = config.getDoubleElse("Simulation.immediate-setback-threshold", 0.1);
         maxAdvantage = config.getDoubleElse("Simulation.max-advantage", 1);
         maxCeiling = config.getDoubleElse("Simulation.max-ceiling", 4);
+        vlScale = Math.max(1.0, config.getDoubleElse("Simulation.vl-scale", 1));
+        maxVlsPerFlag = config.getDoubleElse("Simulation.max-vls-per-flag", -1);
         setbackViolationThreshold = config.getDoubleElse("Simulation.setback-violation-threshold", 1);
         if (maxAdvantage == -1) maxAdvantage = Double.MAX_VALUE;
         if (immediateSetbackThreshold == -1) immediateSetbackThreshold = Double.MAX_VALUE;
+        if (maxVlsPerFlag == -1) maxVlsPerFlag = Double.MAX_VALUE;
     }
 
     public boolean doesOffsetFlag(double offset) {

--- a/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
@@ -51,6 +51,7 @@ public class PunishmentManager implements ConfigReloadable {
                 List<String> checks = (List<String>) map.getOrDefault("checks", new ArrayList<>());
                 List<String> commands = (List<String>) map.getOrDefault("commands", new ArrayList<>());
                 int removeViolationsAfter = (int) map.getOrDefault("remove-violations-after", 300);
+                boolean resetExecuteCounter = (boolean) map.getOrDefault("reset-execute-counter", true);
 
                 List<ParsedCommand> parsed = new ArrayList<>();
                 List<AbstractCheck> checksList = new ArrayList<>();
@@ -88,7 +89,7 @@ public class PunishmentManager implements ConfigReloadable {
                     parsed.add(new ParsedCommand(threshold, interval, commandString));
                 }
 
-                groups.add(new PunishGroup(checksList, parsed, removeViolationsAfter * 1000));
+                groups.add(new PunishGroup(checksList, parsed, removeViolationsAfter * 1000, resetExecuteCounter));
             }
         } catch (Exception e) {
             LogUtil.error("Error while loading punishments.yml! This is likely your fault!", e);
@@ -113,9 +114,22 @@ public class PunishmentManager implements ConfigReloadable {
         for (PunishGroup group : groups) {
             if (group.checks.contains(check)) {
                 final int vl = getViolations(group, check);
-                final int violationCount = group.violations.size();
                 for (ParsedCommand command : group.commands) {
                     String cmd = replaceAlertPlaceholders(command.command, vl, check, verbose);
+
+                    if (group.resetExecuteCounter) {
+                        int expected;
+                        if (vl < command.threshold) {
+                            expected = 0;
+                        } else if (command.interval == 0) {
+                            expected = 1;
+                        } else {
+                            expected = 1 + (vl - command.threshold) / command.interval;
+                        }
+                        if (command.executeCount > expected) {
+                            command.executeCount = expected;
+                        }
+                    }
 
                     @Nullable Set<@Nullable PlatformPlayer> verboseListeners = null;
 
@@ -126,11 +140,11 @@ public class PunishmentManager implements ConfigReloadable {
                         verboseListeners = GrimAPI.INSTANCE.getAlertManager().sendVerbose(component, null);
                     }
 
-                    if (violationCount >= command.threshold) {
-                        // 0 means execute once
-                        // Any other number means execute every X interval
-                        boolean inInterval = command.interval == 0 ? (command.executeCount == 0) : (violationCount % command.interval == 0);
-                        if (inInterval) {
+                    // 0 means execute once
+                    // Any other number means execute every X interval
+                    for (; vl >= (command.threshold + (command.interval * command.executeCount)); command.executeCount++) {
+                        if (command.interval == 0 && command.executeCount > 0) break;
+
                             CommandExecuteEvent executeEvent = new CommandExecuteEvent(player, check, verbose, cmd);
                             GrimAPI.INSTANCE.getEventBus().post(executeEvent);
                             if (executeEvent.isCancelled()) continue;
@@ -138,9 +152,8 @@ public class PunishmentManager implements ConfigReloadable {
                             switch (command.command) {
                                 case "[webhook]" -> GrimAPI.INSTANCE.getDiscordManager().sendAlert(player, verbose, check.getDisplayName(), vl);
                                 case "[log]" -> {
-                                    int vls = (int) group.violations.values().stream().filter((e) -> e == check).count();
                                     String verboseWithoutGl = verbose.replaceAll(" /gl .*", "");
-                                    GrimAPI.INSTANCE.getViolationDatabaseManager().logAlert(player, verboseWithoutGl, check.getDisplayName(), vls);
+                                    GrimAPI.INSTANCE.getViolationDatabaseManager().logAlert(player, verboseWithoutGl, check.getDisplayName(), vl);
                                 }
                                 case "[proxy]" -> ProxyAlertMessenger.sendPluginMessage(cmd);
                                 case "[alert]" -> {
@@ -161,9 +174,6 @@ public class PunishmentManager implements ConfigReloadable {
                                         )
                                 );
                             }
-                        }
-
-                        command.executeCount++;
                     }
                 }
             }
@@ -177,19 +187,44 @@ public class PunishmentManager implements ConfigReloadable {
             if (group.checks.contains(check)) {
                 long currentTime = System.currentTimeMillis();
 
-                group.violations.put(currentTime, check);
-                // Remove violations older than the defined time in the config
-                group.violations.entrySet().removeIf(time -> currentTime - time.getKey() > group.removeViolationsAfter);
+                removeExpired(group, currentTime);
+                group.violations.put(currentTime, new ViolationEntry(check, 1.0));
+            }
+        }
+    }
+
+    public void recordExtraViolations(Check check, int amount) {
+        if (amount <= 0) return;
+        long currentTime = System.currentTimeMillis();
+        for (PunishGroup group : groups) {
+            if (group.checks.contains(check)) {
+                removeExpired(group, currentTime);
+                for (int i = 0; i < amount; i++) {
+                    group.violations.put(currentTime + i, new ViolationEntry(check, 1.0));
+                }
+            }
+        }
+        check.violations += amount;
+    }
+
+    private void removeExpired(PunishGroup group, long now) {
+        Iterator<Map.Entry<Long, ViolationEntry>> it = group.violations.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Long, ViolationEntry> entry = it.next();
+            if (now - entry.getKey() > group.removeViolationsAfter) {
+                ViolationEntry v = entry.getValue();
+                v.check.violations = Math.max(0, v.check.violations - v.amount);
+                it.remove();
             }
         }
     }
 
     private int getViolations(PunishGroup group, Check check) {
-        int vl = 0;
-        for (Check value : group.violations.values()) {
-            if (value == check) vl++;
+        double vl = 0;
+        for (ViolationEntry value : group.violations.values()) {
+            if (value.check == check) vl += value.amount;
         }
-        return vl;
+        return (int) Math.max(vl, Math.ceil(check.violations));
     }
 }
 
@@ -197,8 +232,9 @@ public class PunishmentManager implements ConfigReloadable {
 class PunishGroup {
     public final List<AbstractCheck> checks;
     public final List<ParsedCommand> commands;
-    public final Map<Long, Check> violations = new HashMap<>();
+    public final Map<Long, ViolationEntry> violations = new HashMap<>();
     public final int removeViolationsAfter; // time to remove violations after in milliseconds
+    public final boolean resetExecuteCounter;
 }
 
 @RequiredArgsConstructor
@@ -207,4 +243,10 @@ class ParsedCommand {
     public final int interval;
     public final String command;
     public int executeCount;
+}
+
+@RequiredArgsConstructor
+class ViolationEntry {
+    final Check check;
+    final double amount;
 }

--- a/common/src/main/resources/config/de.yml
+++ b/common/src/main/resources/config/de.yml
@@ -66,6 +66,13 @@ Simulation:
     # Dies soll verhindern, dass der Spieler zu viele Verstöße sammelt und nie in der Lage ist, sie alle zu beseitigen.
     # Standard-Vorteilsgrenze (x-Achse = Sekunden, y-Achse = 1/1000 Block): https://www.desmos.com/calculator/4lovswdarj
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # Schwellenwert für die Verletzungsstufe für den Rückschlag
     # 1 für das alte Verhalten
     setback-violation-threshold: 1

--- a/common/src/main/resources/config/en.yml
+++ b/common/src/main/resources/config/en.yml
@@ -66,6 +66,13 @@ Simulation:
     # This is to stop the player from gathering too many violations and never being able to clear them all
     # Default advantage ceiling (x axis = seconds, y axis = 1/1000 block): https://www.desmos.com/calculator/4lovswdarj
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # Violation level threshold for setback
     # 1 for old behavior
     setback-violation-threshold: 1

--- a/common/src/main/resources/config/es.yml
+++ b/common/src/main/resources/config/es.yml
@@ -67,6 +67,13 @@ Simulation:
     # Esto es para prevenir que el jugador obtenga muchas violaciones y no pueda ser capaz de borrarlas
     # Tope de ventaja por defecto (eje x = segundos, eje y = bloque 1/1000): https://www.desmos.com/calculator/4lovswdarj
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # Umbral del nivel de violación para el retroceso
     # 1 para el comportamiento antiguo
     setback-violation-threshold: 1

--- a/common/src/main/resources/config/fr.yml
+++ b/common/src/main/resources/config/fr.yml
@@ -66,6 +66,13 @@ Simulation:
     # Cela vise à empêcher le joueur d'accumuler trop de violations et de ne jamais pouvoir toutes les réinitialiser.
     # Plafond d'avantage par défaut (l"axe x = secondes, l'axe y = 1/1000 de bloc)) : https://www.desmos.com/calculator/4lovswdarj
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # Seuil du niveau de violation pour le setback
     # 1 pour le comportement ancien
     setback-violation-threshold: 1

--- a/common/src/main/resources/config/it.yml
+++ b/common/src/main/resources/config/it.yml
@@ -58,6 +58,13 @@ Simulation:
     max-advantage: 1
     # Limite massimo di vantaggio accumulabile prima di arretrare il giocatore
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # Soglia del livello di violazione per il setback
     # 1 per il comportamento precedente
     setback-violation-threshold: 1

--- a/common/src/main/resources/config/ja.yml
+++ b/common/src/main/resources/config/ja.yml
@@ -68,6 +68,13 @@ Simulation:
     # これは、プレイヤーが違反を蓄積しすぎて、違反を解消できなくなるのを防ぐためです。
     # デフォルトのアドバンテージの上限 (x軸 = 秒, y軸 = 1/1000ブロック): https://www.desmos.com/calculator/4lovswdarj
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # セットバックの違反レベル閾値
     # 旧仕様の挙動は 1 です
     setback-violation-threshold: 1

--- a/common/src/main/resources/config/nl.yml
+++ b/common/src/main/resources/config/nl.yml
@@ -66,6 +66,13 @@ Simulation:
     # Dit is om te voorkomen dat de speler te veel schendingen verzamelt en ze nooit allemaal kan opruimen
     # Standaard voordelenplatform (x-as = seconden, y-as = 1/1000 blok): https://www.desmos.com/calculator/4lovswdarj
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # Drempelwaarde voor het schendingenniveau voor de terugslag
     # 1 voor het oude gedrag
     setback-violation-threshold: 1

--- a/common/src/main/resources/config/pt.yml
+++ b/common/src/main/resources/config/pt.yml
@@ -67,6 +67,13 @@ Simulation:
     # Isso serve para previnir o jogador de alcançar violações demais e nunca conseguir se livrar delas.
     # Cela de vantagens padrão (eixo X = segundos, eixo Y = 1/1000 blocos): https://www.desmos.com/calculator/4lovswdarj
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # Quantas violações para começar a recuar o jogador?
     # 1 para comportamento antigo
     setback-violation-threshold: 1

--- a/common/src/main/resources/config/ru.yml
+++ b/common/src/main/resources/config/ru.yml
@@ -66,6 +66,13 @@ Simulation:
     # Это сделано для того, чтобы игрок не собирал слишком много нарушений и никогда не смог очистить их все.
     # Потолок преимущества по умолчанию (ось x = секунды, ось y = 1/1000 блока): https://www.desmos.com/calculator/4lovswdarj
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # Порог уровня нарушения для отката
     # 1 для старого поведения
     setback-violation-threshold: 1

--- a/common/src/main/resources/config/tr.yml
+++ b/common/src/main/resources/config/tr.yml
@@ -66,6 +66,13 @@ Simulation:
     # Bu, oyuncunun çok fazla ihlal biriktirmesini ve bunların hepsini temizleyememesini önlemek içindir
     # Varsayılan avantaj tavanı (x ekseni = saniye, y ekseni = 1/1000 blok): https://www.desmos.com/calculator/4lovswdarj
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # Geri alma için ihlal seviyesi eşiği
     # Eski davranış için 1
     setback-violation-threshold: 1

--- a/common/src/main/resources/config/zh.yml
+++ b/common/src/main/resources/config/zh.yml
@@ -71,6 +71,13 @@ Simulation:
     # 这是为了防止玩家收集过多的违规行为，并且永远无法清除所有的违规行为
     # 这是默认配置的样子（x 轴 = seconds ，y 轴 = 1/1000 方块）: https://www.desmos.com/calculator/4lovswdarj
     max-ceiling: 4
+    # How much should we scale VL gain from a flag by the player's advantage?
+    # ≤1 for no scaling (old behavior)
+    vl-scale: 1
+    # Limits the amount of VLs the player could gain from each flag
+    # This is to prevent high latency players from getting large amount of VLs because of lag spikes
+    # -1 to disable
+    max-vls-per-flag: -1
     # 设置回退的违规等级阈值
     # 1 为旧行为
     setback-violation-threshold: 1

--- a/common/src/main/resources/punishments/de.yml
+++ b/common/src/main/resources/punishments/de.yml
@@ -10,6 +10,8 @@ Punishments:
   Simulation:
     # Nach wie vielen Sekunden soll ein Verstoß entfernt werden?
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     # In diesem Abschnitt werden alle Prüfungen mit dem Namen gefunden,
     # Um eine Prüfung auszuschließen, die sonst übereinstimmen würde, setzen Sie ein Ausrufezeichen vor den Namen
     # Zum Beispiel, !BadPacketsN

--- a/common/src/main/resources/punishments/en.yml
+++ b/common/src/main/resources/punishments/en.yml
@@ -10,6 +10,8 @@ Punishments:
   Simulation:
     # After how many seconds should a violation be removed?
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     # This section will match all checks with the name,
     # To exclude a check that would otherwise be matched, put an exclamation mark in front of the name
     # For example, !BadPacketsN

--- a/common/src/main/resources/punishments/es.yml
+++ b/common/src/main/resources/punishments/es.yml
@@ -10,6 +10,8 @@ Punishments:
   Simulation:
     # ¿Después de cuantos segundos deberíamos quitar una violación?
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     # Esta sección incluirá todas las comprobaciones con el nombre
     # Para excluir una comprobación que de otro modo coincidiría, pon un signo de exclamación en frente del nombre
     # Por ejemplo: !BadPacketsN

--- a/common/src/main/resources/punishments/fr.yml
+++ b/common/src/main/resources/punishments/fr.yml
@@ -10,6 +10,8 @@ Punishments:
   Simulation:
     # Au bout de combien de secondes une violation doit-elle être supprimée ?
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     # Cette section correspondra à toutes les vérifications portant le nom indiqué,
     # Pour exclure une vérification qui serait sinon correspondante, placez un point d'exclamation devant le nom.
     # Par exemple, !BadPacketsN

--- a/common/src/main/resources/punishments/it.yml
+++ b/common/src/main/resources/punishments/it.yml
@@ -9,6 +9,8 @@
 Punishments:
   Simulation:
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     checks:
       - "Simulation"
       - "GroundSpoof"

--- a/common/src/main/resources/punishments/ja.yml
+++ b/common/src/main/resources/punishments/ja.yml
@@ -10,6 +10,8 @@ Punishments:
   Simulation:
     # 何秒後に違反をリセットしますか？
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     # このセクションでは、指定した名前と一致するすべてのチェックに対して処罰を設定します
     # 一部のチェックを除外するには、名前の前に「!」を付けます
     # 例: !BadPacketsN

--- a/common/src/main/resources/punishments/nl.yml
+++ b/common/src/main/resources/punishments/nl.yml
@@ -10,6 +10,8 @@ Punishments:
   Simulation:
     # Na hoeveel seconden moet een overtreding worden verwijderd?
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     # Deze sectie zal overeenkomen met alle controles met de naam,
     # Om een controle uit te sluiten die anders wel overeen zou komen, zet je een uitroepteken voor de naam.
     # Bijvoorbeeld, !BadPacketsN

--- a/common/src/main/resources/punishments/pt.yml
+++ b/common/src/main/resources/punishments/pt.yml
@@ -10,6 +10,8 @@ Punishments:
   Simulation:
     # Depois de quantos segundos a violação deve expirar?
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     # Essa sessão combina todas as verificações com os nomes listados abaixo.
     # Para excluir uma verificação que estaria combinada, adicione uma exclamação na frente do nome.
     # Por exemplo: - "!BadPacketsN"

--- a/common/src/main/resources/punishments/ru.yml
+++ b/common/src/main/resources/punishments/ru.yml
@@ -10,6 +10,8 @@ Punishments:
   Simulation:
     # Через сколько секунд нарушение должно быть удалено?
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     # Этот раздел будет соответствовать всем проверкам с указанным именем,
     # Чтобы исключить проверку, которая в противном случае была бы найдена, поставьте восклицательный знак перед именем.
     # Например, !BadPacketsN

--- a/common/src/main/resources/punishments/tr.yml
+++ b/common/src/main/resources/punishments/tr.yml
@@ -10,6 +10,8 @@ Punishments:
   Simulation:
     # Kaç saniye sonra ihlaller kaldırılsın?
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     # Bu bölüm, aşağıdaki adlara sahip tüm kontrollerle eşleşecektir,
     # Aksi takdirde eşleşecek bir denetimi hariç tutmak için, isminin önüne ünlem işareti koyun
     # Örnek olarak, !BadPacketsN

--- a/common/src/main/resources/punishments/zh.yml
+++ b/common/src/main/resources/punishments/zh.yml
@@ -10,6 +10,8 @@ Punishments:
   Simulation:
     # 多少秒后重置VL
     remove-violations-after: 300
+    # Should we reset the command execute counter when the violation level falls below a command's threshold?
+    reset-execute-counter: true
     # 这个部分将会匹配检查的名字
     # 要关闭掉一个检查就在检查前面加感叹号
     # 例如, !BadPacketsN


### PR DESCRIPTION
## Summary
- support scaling Simulation VLs via `vl-scale` and `max-vls-per-flag`
- track extra violations and remove them when they expire
- reset punishment command counters when VL drops using `reset-execute-counter`
- document new options in all language configs

## Testing
- `./gradlew test` *(failed: No route to host)*
- `./gradlew classes` *(failed: No route to host)*