### PR TITLE
Fix bouncy block false flags

### DIFF
--- a/common/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -358,16 +358,19 @@ public class MovementCheckRunner extends Check implements PositionCheck {
             if (data.getType() == StateTypes.SLIME_BLOCK && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8)) {
                 player.uncertaintyHandler.isSteppingOnSlime = true;
                 player.uncertaintyHandler.isSteppingOnBouncyBlock = true;
+                player.uncertaintyHandler.bouncyBlockTicks = 5;
             }
             if (data.getType() == StateTypes.HONEY_BLOCK) {
                 if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_14)
                         && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8)) {
                     player.uncertaintyHandler.isSteppingOnBouncyBlock = true;
+                    player.uncertaintyHandler.bouncyBlockTicks = 5;
                 }
                 player.uncertaintyHandler.isSteppingOnHoney = true;
             }
             if (BlockTags.BEDS.contains(data.getType()) && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_12)) {
                 player.uncertaintyHandler.isSteppingOnBouncyBlock = true;
+                player.uncertaintyHandler.bouncyBlockTicks = 5;
             }
             if (BlockTags.ICE.contains(data.getType())) {
                 player.uncertaintyHandler.isSteppingOnIce = true;

--- a/common/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
@@ -53,6 +53,8 @@ public class UncertaintyHandler {
     public boolean isSteppingOnHoney = false;
     public boolean wasSteppingOnBouncyBlock = false;
     public boolean isSteppingOnBouncyBlock = false;
+    // Track how many ticks ago the player last touched a bouncy block
+    public int bouncyBlockTicks = 0;
     public boolean isSteppingNearBubbleColumn = false;
     public boolean isSteppingNearScaffolding = false;
     public boolean isSteppingNearShulker = false;
@@ -124,6 +126,7 @@ public class UncertaintyHandler {
         wasSteppingOnBouncyBlock = isSteppingOnBouncyBlock;
         isSteppingOnSlime = false;
         isSteppingOnBouncyBlock = false;
+        if (bouncyBlockTicks > 0) bouncyBlockTicks--;
         isSteppingOnIce = false;
         isSteppingOnHoney = false;
         isSteppingNearBubbleColumn = false;
@@ -251,7 +254,7 @@ public class UncertaintyHandler {
     }
 
     public boolean influencedByBouncyBlock() {
-        return isSteppingOnBouncyBlock || wasSteppingOnBouncyBlock;
+        return isSteppingOnBouncyBlock || wasSteppingOnBouncyBlock || bouncyBlockTicks > 0;
     }
 
     public double getVerticalOffset(VectorData data) {
@@ -260,7 +263,7 @@ public class UncertaintyHandler {
             return 0.06;
 
         // We don't know if the player was pressing jump or not
-        if (player.uncertaintyHandler.wasSteppingOnBouncyBlock && (player.wasTouchingWater || player.wasTouchingLava))
+        if (bouncyBlockTicks > 0 && (player.wasTouchingWater || player.wasTouchingLava))
             return 0.06;
 
         // Not worth my time to fix this because checking flying generally sucks - if player was flying in last 2 ticks


### PR DESCRIPTION
## Summary
- extend uncertainty when leaving bouncy blocks so the movement check has extra leniency

## Testing
- `./gradlew tasks --no-daemon` *(fails: No route to host)*