### PR TITLE
Fix punishment command reset

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
@@ -114,6 +114,9 @@ public class PunishmentManager implements ConfigReloadable {
             if (group.checks.contains(check)) {
                 final int vl = getViolations(group, check);
                 for (ParsedCommand command : group.commands) {
+                    if (vl < command.threshold) {
+                        command.executeCount = 0;
+                    }
                     String cmd = replaceAlertPlaceholders(command.command, vl, check, verbose);
 
                     @Nullable Set<@Nullable PlatformPlayer> verboseListeners = null;


### PR DESCRIPTION
## Summary
- reset ParsedCommand executeCount when violations fall below the command threshold

## Testing
- `gradle test --no-daemon --stacktrace` *(fails: Plugin org.gradle.toolchains.foojay-resolver-convention not found)*