### PR TITLE
Add configuration for command resets and VL scaling delay

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/prediction/OffsetHandler.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/prediction/OffsetHandler.java
@@ -21,6 +21,8 @@ public class OffsetHandler extends Check implements PostPredictionCheck {
     double maxAdvantage;
     double maxCeiling;
     double vlScale;
+    long vlScaleDelay;
+    long lastScaledFlagTime = 0;
     double maxVlsPerFlag;
     double setbackViolationThreshold;
     // Current advantage gained
@@ -67,10 +69,11 @@ public class OffsetHandler extends Check implements PostPredictionCheck {
                     }
 
                     double extra = Math.ceil(offset * vlScale) - 1.0;
-                    if (extra > 0) {
+                    if (extra > 0 && (vlScaleDelay <= 0 || System.currentTimeMillis() - lastScaledFlagTime >= vlScaleDelay)) {
                         int amount = (int) Math.min(maxVlsPerFlag, extra);
                         violations += amount;
                         player.punishmentManager.addExtraViolation(this, amount);
+                        lastScaledFlagTime = System.currentTimeMillis();
                     }
 
                     if ((advantageGained >= maxAdvantage || offset >= immediateSetbackThreshold)
@@ -114,6 +117,7 @@ public class OffsetHandler extends Check implements PostPredictionCheck {
         maxAdvantage = config.getDoubleElse("Simulation.max-advantage", 1);
         maxCeiling = config.getDoubleElse("Simulation.max-ceiling", 4);
         vlScale = Math.max(1.0, config.getDoubleElse("Simulation.vl-scale", 1));
+        vlScaleDelay = config.getLongElse("Simulation.vl-scale-delay", 0L);
         maxVlsPerFlag = config.getDoubleElse("Simulation.max-vls-per-flag", -1);
         setbackViolationThreshold = config.getDoubleElse("Simulation.setback-violation-threshold", 1);
         if (maxAdvantage == -1) maxAdvantage = Double.MAX_VALUE;

--- a/common/src/main/java/ac/grim/grimac/checks/impl/prediction/OffsetHandler.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/prediction/OffsetHandler.java
@@ -21,8 +21,6 @@ public class OffsetHandler extends Check implements PostPredictionCheck {
     double maxAdvantage;
     double maxCeiling;
     double vlScale;
-    long vlScaleDelay;
-    long lastScaledFlagTime = 0;
     double maxVlsPerFlag;
     double setbackViolationThreshold;
     // Current advantage gained
@@ -69,11 +67,10 @@ public class OffsetHandler extends Check implements PostPredictionCheck {
                     }
 
                     double extra = Math.ceil(offset * vlScale) - 1.0;
-                    if (extra > 0 && (vlScaleDelay <= 0 || System.currentTimeMillis() - lastScaledFlagTime >= vlScaleDelay)) {
+                    if (extra > 0) {
                         int amount = (int) Math.min(maxVlsPerFlag, extra);
                         violations += amount;
                         player.punishmentManager.addExtraViolation(this, amount);
-                        lastScaledFlagTime = System.currentTimeMillis();
                     }
 
                     if ((advantageGained >= maxAdvantage || offset >= immediateSetbackThreshold)
@@ -117,7 +114,6 @@ public class OffsetHandler extends Check implements PostPredictionCheck {
         maxAdvantage = config.getDoubleElse("Simulation.max-advantage", 1);
         maxCeiling = config.getDoubleElse("Simulation.max-ceiling", 4);
         vlScale = Math.max(1.0, config.getDoubleElse("Simulation.vl-scale", 1));
-        vlScaleDelay = config.getLongElse("Simulation.vl-scale-delay", 0L);
         maxVlsPerFlag = config.getDoubleElse("Simulation.max-vls-per-flag", -1);
         setbackViolationThreshold = config.getDoubleElse("Simulation.setback-violation-threshold", 1);
         if (maxAdvantage == -1) maxAdvantage = Double.MAX_VALUE;

--- a/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
@@ -24,6 +24,7 @@ public class PunishmentManager implements ConfigReloadable {
     String experimentalSymbol = "*";
     private String alertString;
     private boolean testMode;
+    private boolean resetExecuteCount;
     private String proxyAlertString = "";
 
     public PunishmentManager(GrimPlayer player) {
@@ -36,6 +37,7 @@ public class PunishmentManager implements ConfigReloadable {
         experimentalSymbol = config.getStringElse("experimental-symbol", "*");
         alertString = config.getStringElse("alerts-format", "%prefix% &f%player% &bfailed &f%check_name% &f(x&c%vl%&f) &7%verbose%");
         testMode = config.getBooleanElse("test-mode", false);
+        resetExecuteCount = config.getBooleanElse("reset-punishment-execute-count", true);
         proxyAlertString = config.getStringElse("alerts-format-proxy", "%prefix% &f[&cproxy&f] &f%player% &bfailed &f%check_name% &f(x&c%vl%&f) &7%verbose%");
         try {
             groups.clear();
@@ -114,7 +116,7 @@ public class PunishmentManager implements ConfigReloadable {
             if (group.checks.contains(check)) {
                 final int vl = getViolations(group, check);
                 for (ParsedCommand command : group.commands) {
-                    if (vl < command.threshold) {
+                    if (resetExecuteCount && vl < command.threshold) {
                         command.executeCount = 0;
                     }
                     String cmd = replaceAlertPlaceholders(command.command, vl, check, verbose);

--- a/common/src/main/resources/config/de.yml
+++ b/common/src/main/resources/config/de.yml
@@ -69,6 +69,8 @@ Simulation:
     # Wie stark sollen wir den VL-Gewinn anhand des Vorteils des Spielers skaliieren?
     # ≤1 für keine Skalierung (altes Verhalten)
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # Beschränkt die Menge an VL, die pro Flag hinzugefügt werden kann
     # -1 deaktiviert die Begrenzung
     max-vls-per-flag: -1
@@ -188,6 +190,7 @@ debug-pipeline-on-join: false
 
 # Aktiviert experimentelle Prüfungen
 experimental-checks: false
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/en.yml
+++ b/common/src/main/resources/config/en.yml
@@ -69,6 +69,8 @@ Simulation:
     # How much should we scale VL gain from a flag by the player's advantage?
     # ≤1 for no scaling (old behavior)
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # Limits the amount of VLs the player could gain from each flag
     # This is to prevent high latency players from getting large amount of VLs because of lag spikes
     # -1 to disable
@@ -189,6 +191,7 @@ debug-pipeline-on-join: false
 
 # Enables experimental checks
 experimental-checks: false
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/es.yml
+++ b/common/src/main/resources/config/es.yml
@@ -70,6 +70,8 @@ Simulation:
     # ¿Cuánto deberíamos escalar la ganancia de VL por una bandera según la ventaja del jugador?
     # ≤1 para no escalar (comportamiento antiguo)
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # Limita la cantidad de VL que el jugador puede ganar por cada bandera
     # -1 para desactivar
     max-vls-per-flag: -1
@@ -189,6 +191,7 @@ debug-pipeline-on-join: false
 
 # Habilitar comprobaciones experimentales
 experimental-checks: false
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/fr.yml
+++ b/common/src/main/resources/config/fr.yml
@@ -69,6 +69,8 @@ Simulation:
     # Dans quelle mesure doit-on augmenter les VL en fonction de l'avantage du joueur ?
     # ≤1 pour conserver l'ancien comportement sans échelle
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # Limite la quantité de VL que le joueur peut gagner par alerte
     # -1 pour désactiver
     max-vls-per-flag: -1
@@ -184,6 +186,7 @@ debug-pipeline-on-join: false
 
 # Active les vérifications expérimentales
 experimental-checks: false
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/it.yml
+++ b/common/src/main/resources/config/it.yml
@@ -61,6 +61,8 @@ Simulation:
     # Di quanto dobbiamo scalare l'aumento di VL di un flag in base al vantaggio del giocatore?
     # ≤1 per mantenere il vecchio comportamento
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # Limita quante VL si possono ottenere per ogni flag
     # -1 per disattivare
     max-vls-per-flag: -1
@@ -166,6 +168,7 @@ debug-pipeline-on-join: false
 
 # Enables experimental checks
 experimental-checks: false
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/ja.yml
+++ b/common/src/main/resources/config/ja.yml
@@ -71,6 +71,8 @@ Simulation:
     # プレイヤーのアドバンテージに応じてVL増加量をどれだけスケールさせるか
     # 1以下で従来の挙動になります
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # 1回のフラグで増加できるVLの上限
     # -1で無制限
     max-vls-per-flag: -1
@@ -197,6 +199,7 @@ debug-pipeline-on-join: false
 
 # 実験的なチェックを有効にします
 experimental-checks: false
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/nl.yml
+++ b/common/src/main/resources/config/nl.yml
@@ -69,6 +69,8 @@ Simulation:
     # Hoeveel moeten we de VL-verhoging van een flag schalen op basis van het voordeel van de speler?
     # ≤1 voor geen schaal (oud gedrag)
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # Beperkt hoeveel VL een speler per flag kan krijgen
     # -1 om uit te schakelen
     max-vls-per-flag: -1
@@ -188,6 +190,7 @@ debug-pipeline-on-join: false
 
 # Experimentele controles inschakelen
 experimental-checks: false
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/pt.yml
+++ b/common/src/main/resources/config/pt.yml
@@ -70,6 +70,8 @@ Simulation:
     # Quanto devemos escalar o ganho de VL de um flag com base na vantagem do jogador?
     # ≤1 para manter o comportamento antigo
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # Limita a quantidade de VL que o jogador pode ganhar por flag
     # -1 para desativar
     max-vls-per-flag: -1
@@ -193,6 +195,7 @@ debug-pipeline-on-join: false
 
 # Habilita verificações experimentais.
 experimental-checks: false
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/ru.yml
+++ b/common/src/main/resources/config/ru.yml
@@ -69,6 +69,8 @@ Simulation:
     # Насколько увеличивать получение VL в зависимости от преимущества игрока?
     # ≤1 — оставить старое поведение
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # Ограничивает количество VL, которое можно получить за один флаг
     # -1 для отключения
     max-vls-per-flag: -1
@@ -184,6 +186,7 @@ debug-pipeline-on-join: false
 
 # Включает экспериментальные проверки
 experimental-checks: false
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/tr.yml
+++ b/common/src/main/resources/config/tr.yml
@@ -69,6 +69,8 @@ Simulation:
     # Oyuncunun avantajına bağlı olarak VL artışını ne kadar ölçekleyelim?
     # ≤1 eski davranış için
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # Her bir flagden alınabilecek VL miktarını sınırlar
     # -1 devre dışı bırakır
     max-vls-per-flag: -1
@@ -188,6 +190,7 @@ debug-pipeline-on-join: false
 
 # Deneysel kontrolleri etkinleştir
 experimental-checks: false
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/zh.yml
+++ b/common/src/main/resources/config/zh.yml
@@ -74,6 +74,8 @@ Simulation:
     # 根据玩家的优势对VL增量进行缩放
     # ≤1 表示与以前相同
     vl-scale: 1
+    # Delay in milliseconds between flags for VL scaling
+    vl-scale-delay: 0
     # 限制每次触发可增加的VL数量
     # -1 表示不限制
     max-vls-per-flag: -1
@@ -190,6 +192,7 @@ debug-pipeline-on-join: false
 
 # 启用实验性检查
 experimental-checks: false
+reset-punishment-execute-count: true
 
 # 取消有问题的格挡
 reset-item-usage-on-item-update: true


### PR DESCRIPTION
## Summary
- make resetting punishment command counters configurable
- add VL scale delay option in Simulation settings
- update language configs with the new options
- support new delay in `OffsetHandler`

## Testing
- `./gradlew build -x test` *(fails: No route to host)*