### PR TITLE
Add option to disable verbose info in Discord alerts

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/DiscordManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/DiscordManager.java
@@ -37,6 +37,7 @@ public class DiscordManager implements StartableInitable, ReloadableInitable {
     private int embedColor;
     private String staticContent = "";
     private String embedTitle = "";
+    private boolean includeVerboseField = true;
 
     @Override
     public void start() {
@@ -61,6 +62,8 @@ public class DiscordManager implements StartableInitable, ReloadableInitable {
             }
 
             embedTitle = GrimAPI.INSTANCE.getConfigManager().getConfig().getStringElse("embed-title", "**Grim Alert**");
+
+            includeVerboseField = GrimAPI.INSTANCE.getConfigManager().getConfig().getBooleanElse("include-verbose-field", true);
 
             try {
                 embedColor = Color.decode(GrimAPI.INSTANCE.getConfigManager().getConfig().getStringElse("embed-color", "#00FFFF")).getRGB();
@@ -108,7 +111,7 @@ public class DiscordManager implements StartableInitable, ReloadableInitable {
                 .timestamp(Instant.now())
                 .footer(new EmbedFooter("", "https://grim.ac/images/grim.png"));
 
-        if (!verbose.isEmpty()) {
+        if (includeVerboseField && !verbose.isEmpty()) {
             embed.addFields(new EmbedField("Verbose", MessageUtil.filterDiscordText(verbose), true));
         }
 

--- a/common/src/main/java/ac/grim/grimac/manager/config/ConfigManagerFileImpl.java
+++ b/common/src/main/java/ac/grim/grimac/manager/config/ConfigManagerFileImpl.java
@@ -81,7 +81,7 @@ public class ConfigManagerFileImpl implements ConfigManager, BasicReloadable {
 
                     configVersion = Integer.parseInt(configStringVersion);
                     // TODO: Do we have to hardcode this?
-                    configString = configString.replaceAll("config-version: " + configStringVersion, "config-version: 9");
+                    configString = configString.replaceAll("config-version: " + configStringVersion, "config-version: 10");
                     Files.write(config.toPath(), configString.getBytes());
 
                     upgradeModernConfig(config, configString, configVersion);
@@ -122,6 +122,9 @@ public class ConfigManagerFileImpl implements ConfigManager, BasicReloadable {
         }
         if (configVersion < 9) {
             newOffsetHandlingAntiKB(config, configString);
+        }
+        if (configVersion < 10) {
+            addDiscordVerboseField();
         }
     }
 
@@ -285,6 +288,21 @@ public class ConfigManagerFileImpl implements ConfigManager, BasicReloadable {
                         "  max-ceiling: 4"
         );
         Files.write(config.toPath(), configString.getBytes());
+    }
+
+    private void addDiscordVerboseField() {
+        File discordFile = new File(GrimAPI.INSTANCE.getGrimPlugin().getDataFolder(), "discord.yml");
+
+        if (discordFile.exists()) {
+            try {
+                String discordString = new String(Files.readAllBytes(discordFile.toPath()));
+                if (!discordString.contains("include-verbose-field")) {
+                    discordString += "\ninclude-verbose-field: true\n";
+                    Files.write(discordFile.toPath(), discordString.getBytes());
+                }
+            } catch (IOException ignored) {
+            }
+        }
     }
 
     @Override

--- a/common/src/main/resources/config/de.yml
+++ b/common/src/main/resources/config/de.yml
@@ -228,4 +228,4 @@ history:
         username: root
         password: ""
 
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/config/en.yml
+++ b/common/src/main/resources/config/en.yml
@@ -229,4 +229,4 @@ history:
         username: root
         password: ""
 
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/config/es.yml
+++ b/common/src/main/resources/config/es.yml
@@ -230,4 +230,4 @@ history:
         username: root
         password: ""
 
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/config/fr.yml
+++ b/common/src/main/resources/config/fr.yml
@@ -225,4 +225,4 @@ history:
         username: root
         password: ""
 
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/config/it.yml
+++ b/common/src/main/resources/config/it.yml
@@ -206,4 +206,4 @@ history:
         username: root
         password: ""
 
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/config/ja.yml
+++ b/common/src/main/resources/config/ja.yml
@@ -237,4 +237,4 @@ history:
         username: root
         password: ""
 
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/config/nl.yml
+++ b/common/src/main/resources/config/nl.yml
@@ -228,4 +228,4 @@ history:
         username: root
         password: ""
 
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/config/pt.yml
+++ b/common/src/main/resources/config/pt.yml
@@ -233,4 +233,4 @@ history:
         username: root
         password: ""
 
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/config/ru.yml
+++ b/common/src/main/resources/config/ru.yml
@@ -224,4 +224,4 @@ history:
         username: root
         password: ""
 
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/config/tr.yml
+++ b/common/src/main/resources/config/tr.yml
@@ -228,4 +228,4 @@ history:
         username: root
         password: ""
 
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/config/zh.yml
+++ b/common/src/main/resources/config/zh.yml
@@ -232,4 +232,4 @@ history:
         password: ""
 
 # 不要调整这个
-config-version: 9
+config-version: 10

--- a/common/src/main/resources/discord/de.yml
+++ b/common/src/main/resources/discord/de.yml
@@ -10,3 +10,4 @@ violation-content:
     - "**Marke**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"
+include-verbose-field: true

--- a/common/src/main/resources/discord/en.yml
+++ b/common/src/main/resources/discord/en.yml
@@ -10,3 +10,5 @@ violation-content:
     - "**Brand**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"
+include-verbose-field: true
+

--- a/common/src/main/resources/discord/es.yml
+++ b/common/src/main/resources/discord/es.yml
@@ -21,3 +21,4 @@ violation-content:
     - "**Marca del cliente**: %brand%"
     - "**Latencia**: %ping%"
     - "**TPS**: %tps%"
+include-verbose-field: true

--- a/common/src/main/resources/discord/fr.yml
+++ b/common/src/main/resources/discord/fr.yml
@@ -10,3 +10,4 @@ violation-content:
     - "**Nature du client**: %brand%"
     - "**Latence**: %ping%"
     - "**TPS**: %tps%"
+include-verbose-field: true

--- a/common/src/main/resources/discord/it.yml
+++ b/common/src/main/resources/discord/it.yml
@@ -10,3 +10,4 @@ violation-content:
     - "**Client**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"
+include-verbose-field: true

--- a/common/src/main/resources/discord/ja.yml
+++ b/common/src/main/resources/discord/ja.yml
@@ -13,3 +13,4 @@ violation-content:
     - "**ブランド**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"
+include-verbose-field: true

--- a/common/src/main/resources/discord/nl.yml
+++ b/common/src/main/resources/discord/nl.yml
@@ -10,3 +10,4 @@ violation-content:
     - "**Client-merk**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"
+include-verbose-field: true

--- a/common/src/main/resources/discord/pt.yml
+++ b/common/src/main/resources/discord/pt.yml
@@ -10,3 +10,4 @@ violation-content:
     - "**Nome do Cliente**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"
+include-verbose-field: true

--- a/common/src/main/resources/discord/ru.yml
+++ b/common/src/main/resources/discord/ru.yml
@@ -11,3 +11,4 @@ violation-content:
     - "**Бренд**: %brand%"
     - "**Пинг**: %ping%"
     - "**ТПС**: %tps%"
+include-verbose-field: true

--- a/common/src/main/resources/discord/tr.yml
+++ b/common/src/main/resources/discord/tr.yml
@@ -9,3 +9,4 @@ violation-content:
     - "**Kullanılan Client**: %brand%"
     - "**Gecikme**: %ping%"
     - "**TPS**: %tps%"
+include-verbose-field: true

--- a/common/src/main/resources/discord/zh.yml
+++ b/common/src/main/resources/discord/zh.yml
@@ -11,3 +11,4 @@ violation-content:
     - "**客户端品牌**: %brand%"
     - "**延迟**: %ping%"
     - "**服务器卡顿程度**: %tps%"
+include-verbose-field: true


### PR DESCRIPTION
## Summary
- add `include-verbose-field` toggle for Discord webhooks
- bump config version to 10 and upgrade config on reload
- default all language files to include verbose field

## Testing
- `./gradlew build` *(fails: No route to host)*