### PR TITLE
Fix punishment execute count reset

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
@@ -24,6 +24,7 @@ public class PunishmentManager implements ConfigReloadable {
     String experimentalSymbol = "*";
     private String alertString;
     private boolean testMode;
+    private boolean resetExecuteCount;
     private String proxyAlertString = "";
 
     public PunishmentManager(GrimPlayer player) {
@@ -36,6 +37,7 @@ public class PunishmentManager implements ConfigReloadable {
         experimentalSymbol = config.getStringElse("experimental-symbol", "*");
         alertString = config.getStringElse("alerts-format", "%prefix% &f%player% &bfailed &f%check_name% &f(x&c%vl%&f) &7%verbose%");
         testMode = config.getBooleanElse("test-mode", false);
+        resetExecuteCount = config.getBooleanElse("reset-punishment-execute-count", true);
         proxyAlertString = config.getStringElse("alerts-format-proxy", "%prefix% &f[&cproxy&f] &f%player% &bfailed &f%check_name% &f(x&c%vl%&f) &7%verbose%");
         try {
             groups.clear();
@@ -115,6 +117,9 @@ public class PunishmentManager implements ConfigReloadable {
                 final int vl = getViolations(group, check);
                 final int violationCount = group.violations.size();
                 for (ParsedCommand command : group.commands) {
+                    if (resetExecuteCount && vl < command.threshold) {
+                        command.executeCount = 0;
+                    }
                     String cmd = replaceAlertPlaceholders(command.command, vl, check, verbose);
 
                     @Nullable Set<@Nullable PlatformPlayer> verboseListeners = null;

--- a/common/src/main/resources/config/de.yml
+++ b/common/src/main/resources/config/de.yml
@@ -185,6 +185,8 @@ debug-pipeline-on-join: false
 
 # Aktiviert experimentelle Prüfungen
 experimental-checks: false
+# Setzt die Ausführungsanzahl einer Bestrafung zurück, wenn der VL unter den Schwellenwert fällt
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/en.yml
+++ b/common/src/main/resources/config/en.yml
@@ -185,6 +185,8 @@ debug-pipeline-on-join: false
 
 # Enables experimental checks
 experimental-checks: false
+# Resets how many times a punishment command has executed when the player's VL drops below its threshold
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/es.yml
+++ b/common/src/main/resources/config/es.yml
@@ -186,6 +186,8 @@ debug-pipeline-on-join: false
 
 # Habilitar comprobaciones experimentales
 experimental-checks: false
+# Restablece el conteo de ejecuciones del castigo cuando el VL del jugador baja del umbral
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/fr.yml
+++ b/common/src/main/resources/config/fr.yml
@@ -181,6 +181,8 @@ debug-pipeline-on-join: false
 
 # Active les vérifications expérimentales
 experimental-checks: false
+# Réinitialise le nombre d'exécutions de la sanction lorsque le VL du joueur repasse sous le seuil
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/it.yml
+++ b/common/src/main/resources/config/it.yml
@@ -163,6 +163,8 @@ debug-pipeline-on-join: false
 
 # Enables experimental checks
 experimental-checks: false
+# Reimposta il conteggio di esecuzione della punizione quando il VL del giocatore scende sotto la soglia
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/ja.yml
+++ b/common/src/main/resources/config/ja.yml
@@ -194,6 +194,8 @@ debug-pipeline-on-join: false
 
 # 実験的なチェックを有効にします
 experimental-checks: false
+# プレイヤーのVLがしきい値を下回ったときに制裁実行回数をリセット
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/nl.yml
+++ b/common/src/main/resources/config/nl.yml
@@ -185,6 +185,8 @@ debug-pipeline-on-join: false
 
 # Experimentele controles inschakelen
 experimental-checks: false
+# Reset het aantal keren dat een straf is uitgevoerd wanneer de VL onder de drempel zakt
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/pt.yml
+++ b/common/src/main/resources/config/pt.yml
@@ -190,6 +190,8 @@ debug-pipeline-on-join: false
 
 # Habilita verificações experimentais.
 experimental-checks: false
+# Reinicia a contagem de execuções da punição quando o VL do jogador fica abaixo do limite
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/ru.yml
+++ b/common/src/main/resources/config/ru.yml
@@ -181,6 +181,8 @@ debug-pipeline-on-join: false
 
 # Включает экспериментальные проверки
 experimental-checks: false
+# Сбрасывать количество выполнения наказания, когда VL игрока опускается ниже порога
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/tr.yml
+++ b/common/src/main/resources/config/tr.yml
@@ -185,6 +185,8 @@ debug-pipeline-on-join: false
 
 # Deneysel kontrolleri etkinleştir
 experimental-checks: false
+# Oyuncunun VL degeri esik altina dustugunde cezanin yurutulme sayisini sifirlar
+reset-punishment-execute-count: true
 
 reset-item-usage-on-item-update: true
 reset-item-usage-on-attack: true

--- a/common/src/main/resources/config/zh.yml
+++ b/common/src/main/resources/config/zh.yml
@@ -187,6 +187,8 @@ debug-pipeline-on-join: false
 
 # 启用实验性检查
 experimental-checks: false
+# 当玩家的VL低于阈值时重置头期执行次数
+reset-punishment-execute-count: true
 
 # 取消有问题的格挡
 reset-item-usage-on-item-update: true


### PR DESCRIPTION
## Summary
- add configurable `resetExecuteCount` flag
- reset punishment command execution count when VL drops below threshold
- document `reset-punishment-execute-count` in config files

## Testing
- `./gradlew build` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871ad8e9ae4833398eda44dd1d577bc